### PR TITLE
Implement handling for air pollution API requests

### DIFF
--- a/air_pollution_api.py
+++ b/air_pollution_api.py
@@ -1,0 +1,33 @@
+import requests
+import os
+
+
+def get_air_pollution(coordinates: list) -> int:
+    """
+    Returns the Air Quality Index for a given set of coordinates from
+    OpenWeatherMap's data set.
+
+    Args:
+        coords (list): The latitude and longitude (respectively) of a given
+            location.
+
+    Returns:
+        int: The location's Air Quality Index.
+
+    Raises:
+        HTTPError: If the HTTP request was unsuccessful.
+    """
+
+    endpoint = "http://api.openweathermap.org/data/2.5/air_pollution"
+    payload = {
+        "lat": coordinates[0],
+        "lon": coordinates[1],
+        "appid": os.environ["OWM_API_KEY"],
+    }
+
+    response = requests.get(endpoint, params=payload)
+
+    # will raise an HTTPError if the request was unsuccessful
+    response.raise_for_status()
+
+    return response.json()["list"][0]["main"]["aqi"]

--- a/air_pollution_api.py
+++ b/air_pollution_api.py
@@ -22,7 +22,7 @@ def get_air_pollution(coordinates: list) -> int:
         int: The location's Air Quality Index.
 
     Raises:
-        HTTPError: If the HTTP request was unsuccessful.
+        AirPollutionAPIError: If the HTTP request was unsuccessful.
     """
 
     endpoint = "http://api.openweathermap.org/data/2.5/air_pollution"

--- a/air_pollution_api.py
+++ b/air_pollution_api.py
@@ -2,6 +2,13 @@ import requests
 import os
 
 
+class AirPollutionAPIError(Exception):
+    """Raised when requests made to the air pollution API are unsuccessful."""
+
+    def __init__(self, msg):
+        self.msg = msg
+
+
 def get_air_pollution(coordinates: list) -> int:
     """
     Returns the Air Quality Index for a given set of coordinates from
@@ -28,6 +35,9 @@ def get_air_pollution(coordinates: list) -> int:
     response = requests.get(endpoint, params=payload)
 
     # will raise an HTTPError if the request was unsuccessful
-    response.raise_for_status()
+    try:
+        response.raise_for_status()
+    except requests.HTTPError:
+        raise AirPollutionAPIError
 
     return response.json()["list"][0]["main"]["aqi"]


### PR DESCRIPTION
Added air_pollution_api.py, which contains get_air_pollution. This function returns the AQI of any given place on a scale of 1 to 5, where 1 is the cleanest and 5 is the poorest.

Note: in order to make a request, the environment variable OWM_API_KEY must be set to a valid OpenWeatherMap API key.